### PR TITLE
Package listing responsiveness fix

### DIFF
--- a/src/pkgx.dev/PackageListing.tsx
+++ b/src/pkgx.dev/PackageListing.tsx
@@ -1,8 +1,7 @@
 import { Box, Button, Stack, Typography } from '@mui/material';
-import { useEffect, useState } from 'react';
-import { S3Client, ListObjectsV2Command, _Object } from "@aws-sdk/client-s3";
+import { S3Client, ListObjectsV2Command, _Object } from '@aws-sdk/client-s3';
 import { Link, useParams } from 'react-router-dom';
-import { useAsync } from "react-use"
+import { useAsync } from 'react-use';
 import Footer from '../components/Footer';
 import Masthead from '../components/Masthead';
 
@@ -79,8 +78,8 @@ function PackageListingMeat() {
 
 function Listing({ dirs }: { dirs: string[] }) {
   return <ul>
-    {dirs.map(obj => <li>
-      <Link key={obj} to={`/pkgs/${obj}`}>{obj}</Link>
+    {dirs.map(obj => <li key={obj}>
+      <Link to={`/pkgs/${obj}`}>{obj}</Link>
     </li>)}
   </ul>
 }

--- a/src/pkgx.dev/PackageListing.tsx
+++ b/src/pkgx.dev/PackageListing.tsx
@@ -86,7 +86,7 @@ function Listing({ dirs }: { dirs: string[] }) {
 }
 
 function Package({ project, dirs }: { project: string, dirs: string[] }) {
-  return <Stack direction='row' spacing={4}>
+  return <Stack direction={{xs: "column", md: "row"}} spacing={4}>
     <img src={`https://gui.tea.xyz/prod/${project}/1024x1024.webp`} width={375} height={375} />
     <Box>
       <h1>{project}</h1>


### PR DESCRIPTION
Breaks in to a column view on smaller viewports - also includes a console error fix and removes unused imports

**Before**
<img width="220" alt="Screenshot 2023-10-28 at 12 02 29 PM" src="https://github.com/pkgxdev/www/assets/8732757/24957406-fe45-4858-a2f4-0a5bd1585968">

**After**
<img width="237" alt="Screenshot 2023-10-28 at 12 02 11 PM" src="https://github.com/pkgxdev/www/assets/8732757/2f88d11c-3d28-42c5-b8aa-2d867576f4da">


