### PR TITLE
Show latest pkgx versions first

### DIFF
--- a/src/pkgx.dev/PackageListing.tsx
+++ b/src/pkgx.dev/PackageListing.tsx
@@ -289,8 +289,10 @@ function Versions({ project }: { project: string }) {
   const state = useAsync(async () => {
     let rsp = await fetch(`https://dist.pkgx.dev/${project}/darwin/aarch64/versions.txt`);
     if (!rsp.ok) rsp = await fetch(`https://dist.pkgx.dev/${project}/linux/x86-64/versions.txt`);
-    const txt = await rsp.text()
-    return txt.split("\n")
+    const txt = await rsp.text();
+    const versions = txt.split("\n");
+    const sortedVersions = versions.sort().reverse();
+    return sortedVersions;
   }, [project]);
 
   if (state.loading) {

--- a/src/pkgx.dev/PackageListing.tsx
+++ b/src/pkgx.dev/PackageListing.tsx
@@ -291,8 +291,7 @@ function Versions({ project }: { project: string }) {
     if (!rsp.ok) rsp = await fetch(`https://dist.pkgx.dev/${project}/linux/x86-64/versions.txt`);
     const txt = await rsp.text();
     const versions = txt.split("\n");
-    const sortedVersions = versions.sort().reverse();
-    return sortedVersions;
+    return versions.sort().reverse();
   }, [project]);
 
   if (state.loading) {


### PR DESCRIPTION
For a package with a lot of versions, I have to scroll down to see if a latest version is available from pkgx.
This PR sorts the versions to show the latest on top!