### PR TITLE
Change to tea

### DIFF
--- a/src/pkgx.dev.tsx
+++ b/src/pkgx.dev.tsx
@@ -34,7 +34,7 @@ ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
             <Route path='/terms-of-use' element={<TermsOfUse/>} />
             <Route path='/pkgs' element={<PackageShowcase />} />
             <Route path='/pkgs/*' element={<PackageListing/>} />
-            <Route path='/tea-protocol' element={<TeaProtocol />} />
+            <Route path='/tea' element={<TeaProtocol />} />
           </Routes>
           <Footer/>
         </Stack>


### PR DESCRIPTION
@mxcl This changes the permalink to the tea protocol landing page from `/tea-protocol` to `/tea` as requested by Timothy.